### PR TITLE
make url_scheme and match_regex nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -225,10 +225,12 @@ components:
               type: string
               example: '^\w*TOKENVAL\w*$'
               description: "An optional regex string which must have a match in the returned webpage contents for the challenge to be successful. This is checked in addition to ensuring the token is contained in the webpage."
+              nullable: true
             url_scheme:
               description: "HTTP (port 80) or HTTPS (port 443). If not specified, the protocol is assumed to be HTTP."
               type: string
               enum: ['http', 'https']
+              nullable: true
             http_headers:
               $ref: '#/components/schemas/HTTPHeaders'
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,7 +8,7 @@ info:
     email: open-mpic@princeton.edu
   license:
     name: MIT License
-  version: 3.3.0
+  version: 3.3.1
 
 externalDocs:
   description: Find out more about the project at open-mpic.org


### PR DESCRIPTION
add additional flexibility in calls. Null values can be handled the same as missing values in processing