### PR TITLE
adding an allow_lookup_failure flag for CAA checks to accommodate BRs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -181,7 +181,7 @@ components:
           type: boolean
           example: false
           default: false
-          description: "If true, a failure to complete the CAA lookup (DNS resolution failure, specifically a DNS resolution timeout or SERVFAIL) will be treated as if no CAA records were found (that is, as permission to issue). If false, a failure to complete the CAA lookup will result in a failed check. Defaults to False. Use with great caution! This is intended to accommodate a carve-out in the CA/Browser Forum Baseline Requirements for CAA checking that allows CAA lookup failures to be treated as permission to issue in certain circumstances, but verifying that those circumstances hold true is left to the CA (in other words, the MPIC client)."
+          description: "If true, a failure to complete the CAA lookup (DNS resolution failure, specifically a DNS resolution timeout or SERVFAIL) will be treated as if no CAA records were found (that is, as permission to issue). If false, a failure to complete the CAA lookup will result in a failed check. Defaults to False. Use with great caution! This is intended to accommodate a carve-out in the CA/Browser Forum Baseline Requirements for CAA checking that allows CAA lookup failures to be treated as permission to issue in certain, narrow circumstances. Because this option weakens a security check, it must be used with great caution, and the Issuing Certificate Authority (CA), which utilizes the MPIC client, is entirely responsible for both enabling this feature and validating that the specific circumstances of the DNS failure justify overriding the standard security requirement."
 
     ValidationMethod:
       description: "The type of domain control validation the network perspectives should use."

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,7 +8,7 @@ info:
     email: open-mpic@princeton.edu
   license:
     name: MIT License
-  version: 3.5.0
+  version: 3.6.0
 
 externalDocs:
   description: Find out more about the project at open-mpic.org
@@ -177,6 +177,11 @@ components:
           description: "Valid CAA domain names in issue or issuewild (e.g., CAA 0 issue \"letsencrypt.org\") tags that permit issuance by the calling CA. If left empty, the default configured CAA domain name(s) are used."
           items:
             type: string
+        allow_lookup_failure:
+          type: boolean
+          example: false
+          default: false
+          description: "If true, a failure to complete the CAA lookup (DNS resolution failure, specifically a DNS resolution timeout or SERVFAIL) will be treated as if no CAA records were found (that is, as permission to issue). If false, a failure to complete the CAA lookup will result in a failed check. Defaults to False. Use with great caution! This is intended to accommodate a carve-out in the CA/Browser Forum Baseline Requirements for CAA checking that allows CAA lookup failures to be treated as permission to issue in certain circumstances, but verifying that those circumstances hold true is left to the CA (in other words, the MPIC client)."
 
     ValidationMethod:
       description: "The type of domain control validation the network perspectives should use."


### PR DESCRIPTION
This pull request updates the OpenAPI specification to introduce a new configuration option for CAA lookup behavior and bumps the API version. The main changes are an added `allow_lookup_failure` property to the relevant schema and a version update.

Enhancements to CAA lookup configuration:

* Added the `allow_lookup_failure` boolean property to the relevant schema, allowing clients to specify how DNS resolution failures during CAA checks should be handled. This provides flexibility to treat lookup failures as permission to issue certificates, in accordance with CA/Browser Forum Baseline Requirements.

Version update:

* Updated the API version in the `info` section from `3.5.0` to `3.6.0` to reflect the new changes.